### PR TITLE
Fix behaviour for default config

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -1,8 +1,9 @@
 package conf
 
 import (
-	"github.com/spf13/viper"
 	"log"
+
+	"github.com/spf13/viper"
 )
 
 //ServerConfig represents Main service configuration
@@ -44,7 +45,7 @@ func LoadConfig(file string) *RpConfig {
 	config.AutomaticEnv()
 	err := config.ReadInConfig()
 	if err != nil {
-		log.Fatal("No configuration file loaded - using defaults")
+		log.Println("No configuration file loaded - using defaults")
 	}
 
 	var rpConf RpConfig

--- a/conf/config_test.go
+++ b/conf/config_test.go
@@ -1,13 +1,24 @@
 package conf
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestLoadConfig(t *testing.T) {
-
-	var rpConf = LoadConfig("./../server.yaml")
+	rpConf := LoadConfig("./../server.yaml")
 	if "10.200.10.1" != rpConf.Server.Hostname {
 		t.Error("Config parser fails")
+	}
+}
+
+func TestLoadConfigUnexisted(t *testing.T) {
+	rpConf := LoadConfig("server.yaml")
+	if rpConf.Server.Hostname != "" {
+		t.Error("Should return empty string for default config")
+	}
+}
+
+func TestLoadConfigIncorrectFormat(t *testing.T) {
+	rpConf := LoadConfig("config_test.go")
+	if rpConf.Server.Hostname != "" {
+		t.Error("Should return empty string for default config")
 	}
 }


### PR DESCRIPTION
With the current implementation, a program will exit if it will not be able to parse config. This commit fixes it.